### PR TITLE
GoogleAPI startRow/paging support and Data capture loop to import multiple dates

### DIFF
--- a/organic-search-analytics/apis/Google/Service/Webmasters.php
+++ b/organic-search-analytics/apis/Google/Service/Webmasters.php
@@ -738,6 +738,7 @@ class Google_Service_Webmasters_SearchAnalyticsQueryRequest extends Google_Colle
   public $dimensions;
   public $endDate;
   public $rowLimit;
+  public $startRow;
   public $searchType;
   public $startDate;
 
@@ -781,6 +782,14 @@ class Google_Service_Webmasters_SearchAnalyticsQueryRequest extends Google_Colle
   public function getRowLimit()
   {
     return $this->rowLimit;
+  }
+  public function setStartRow($startRow)
+  {
+    $this->startRow = $startRow;
+  }
+  public function getStartRow()
+  {
+    return $this->startRow;
   }
   public function setSearchType($searchType)
   {

--- a/organic-search-analytics/data-capture-run.php
+++ b/organic-search-analytics/data-capture-run.php
@@ -5,7 +5,7 @@ $params = false;
 
 if( isset( $_GET ) && is_array( $_GET ) && count( $_GET ) > 0 ) {
 	$params = $_GET;
-} elseif( isset( $argv ) && is_array( $argv ) && count( $argv ) >= 4 ) {
+} elseif( isset( $argv ) && is_array( $argv ) && count( $argv ) >= 3 ) {
 	$params = array();
 	$params['type'] = $argv[1];
 	$params['domain'] = $argv[2];
@@ -28,17 +28,20 @@ if( isset( $_GET ) && is_array( $_GET ) && count( $_GET ) > 0 ) {
 	if( isset( $argv[8] ) ) {
 		$params['search_type'] = $argv[8];
 	}
+	if( isset( $argv[9] ) ) {
+		$params['start_row'] = $argv[9];
+	}
 }
 
-
-if( isset($params) && isset($params['type']) && isset($params['domain']) && isset($params['date']) && preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/",$params['date']) ) {
+if( isset($params) && isset($params['type']) && isset($params['domain']) /*&& isset($params['date'])*/ && (preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/",$params['date']) || $params['date'] == null) ) {
 	/* Set the max allowed execution time for the page to allow for longer procesing times. */
 	ini_set('max_execution_time', 600);  //300 seconds = 5 minutes
-
+        
 	/* Set overrides from URL paramters */
 	$overrideSettings = array();
 	if( isset( $params['mode'] ) ) { $overrideSettings['mode'] = $params['mode']; }
 	if( isset( $params['row_limit'] ) ) { $overrideSettings['row_limit'] = $params['row_limit']; }
+	if( isset( $params['start_row'] ) ) { $overrideSettings['start_row'] = $params['start_row']; }
 	if( isset( $params['dimensions'] ) ) { $overrideSettings['dimensions'] = explode( ',', $params['dimensions'] ); }
 	if( isset( $params['search_type'] ) ) { $overrideSettings['search_type'] = explode( ',', $params['search_type'] ); }
 	if( isset( $params['filters'] ) ) {
@@ -56,16 +59,50 @@ if( isset($params) && isset($params['type']) && isset($params['domain']) && isse
 
 	switch( $params['type'] ) {
 		case 'googleSearchAnalytics':
-			$recordsImported = $dataCapture->downloadGoogleSearchAnalytics( $params['domain'],$params['date'], $overrideSettings );
-			if( !isset( $params['mode'] ) || $params['mode'] != 'return' ) {
-				switch( $recordsImported ) {
-					case -1:
-						echo "There was an error in authorizing your API connection.";
-						break;
-					default:
-						echo number_format( $recordsImported ) . " records succesfully imported to the database for " . $params['domain'] . " for date: " . $params['date'] . ".";
-				}
-			}
+                        if( $params['date'] == '' ) {
+                            $maxDaysBatchImport = 1;
+                            if( defined( 'config::maxDaysBatchImport' ) ) {
+                                $maxDaysBatchImport = min(max(config::maxDaysBatchImport, 1), 999);
+                            }
+                            $googleSearchAnalyticsDates = $dataCapture->checkNeededDataGoogleSearchAnalytics($params['domain']);
+                            if( count( $googleSearchAnalyticsDates['datesWithNoData'] ) > 0 ) {
+                                $i=0;
+                                foreach( $googleSearchAnalyticsDates['datesWithNoData'] as $date ) {
+                                    if( $i < $maxDaysBatchImport ) {
+                                        echo "\n".$date.': ';
+                                        $recordsImported = $dataCapture->downloadGoogleSearchAnalyticsPaged( $params['domain'], $date, $overrideSettings );
+                                        if( !isset( $params['mode'] ) || $params['mode'] != 'return' ) {
+                                                switch( $recordsImported ) {
+                                                        case -1:
+                                                                echo "There was an error in authorizing your API connection.";
+                                                                break;
+                                                        default:
+                                                                echo number_format( $recordsImported ) . " records succesfully imported to the database for " . $params['domain'] . " for date: " . $params['date'] . ".";
+                                                }
+                                        }
+                                        else {
+                                            break;
+                                        }
+                                        sleep(1); //make sure Google limits are not hit
+                                    }
+                                    $i++;
+                                }
+                            }
+                        }
+                        else {
+                            $recordsImported = $dataCapture->downloadGoogleSearchAnalyticsPaged( $params['domain'],$params['date'], $overrideSettings );
+                            if( !isset( $params['mode'] ) || $params['mode'] != 'return' ) {
+                                    switch( $recordsImported ) {
+                                            case -1:
+                                                    echo "There was an error in authorizing your API connection.";
+                                                    break;
+                                            default:
+                                                    echo number_format( $recordsImported ) . " records succesfully imported to the database for " . $params['domain'] . " for date: " . $params['date'] . ".";
+                                    }
+                            }
+                        }
+
+
 			break;
 		case 'bingSearchKeywords':
 			$recordsImported = $dataCapture->downloadBingSearchKeywords($params['domain'],$params['date'], $overrideSettings);


### PR DESCRIPTION
GoogleAPI startRow/paging support:
GoogleAPI supports startRow to page through >5000 results. Thats implemented and can be configered in config/config.php Class Config const downloadGoogleMaxPages = 99;

Data capture via CLI/Cronjob was a little bit difficult because the dates were not clear.
Now its possible to loop the import through multiple dates from CLI.
Use Config: const maxDaysBatchImport = 99; to allow/limit that.